### PR TITLE
fix: ダイアログクローズ時にmutateが動作するのを修正

### DIFF
--- a/src/pages/todo/components/AddTodoDialog.tsx
+++ b/src/pages/todo/components/AddTodoDialog.tsx
@@ -45,7 +45,7 @@ export const AddTodoDialog: FC<Props> = ({ isOpen, onClose }) => {
   }, [createTodo, handleSubmit]);
 
   return (
-    <DialogBase isOpen={isOpen} onClose={onClose}>
+    <DialogBase isOpen={isOpen} onClose={() => onClose()}>
       <form
         className="flex flex-col"
         onSubmit={(e) => {


### PR DESCRIPTION
onclick のイベントが入ってしまってた

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps the `onClose` prop for `DialogBase` in `AddTodoDialog` to explicitly call `onClose()`.
> 
> - **UI (Todo)**:
>   - In `src/pages/todo/components/AddTodoDialog.tsx`, change `DialogBase` `onClose` from `onClose` to `() => onClose()` to explicitly invoke the close handler.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3c411a5e60fa060dd33ad61e288c8b350a6520f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->