### PR TITLE
feat: タスクのタイトルと説明を変更できるように

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,7 +43,7 @@ export default tseslint.config({
     // 余計な<></>が入っていないか確認する
     'react/jsx-no-useless-fragment': ['warn'],
     // () => {return <></>}ではなく、()=> <></>と表記するように
-    'arrow-body-style': ['error'],
+    'arrow-body-style': ['off'],
     // importは一番最初に書くように
     // 'import/first': 'error',
     // 比較演算子の"=="を”＝＝＝”に修正する

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
         "openapi-fetch": "^0.13.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.53.1",
         "react-router-dom": "^7.5.3",
-        "swr": "^2.2.5"
+        "swr": "^2.2.5",
+        "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
@@ -4089,6 +4091,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -9853,6 +9864,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.1.7",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,15 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
     "openapi-fetch": "^0.13.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.53.1",
     "react-router-dom": "^7.5.3",
-    "swr": "^2.2.5"
+    "swr": "^2.2.5",
+    "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/utils';
 import React, { MouseEvent } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -10,13 +11,17 @@ interface ButtonProps {
   href?: string;
   width?: React.CSSProperties['width'];
   style?: React.CSSProperties;
+  className?: string;
 }
 
 export const Button: React.FC<ButtonProps> = (props) =>
   props.href ? (
     <Link
       to={props.href}
-      className="flex cursor-pointer items-center justify-center rounded border border-border p-2 hover:bg-bg-base-hover disabled:cursor-not-allowed disabled:opacity-50 dark:border-border-dark hover:dark:bg-bg-base-hover-dark"
+      className={cn(
+        'flex cursor-pointer items-center justify-center rounded border border-border p-2 hover:bg-bg-base-hover disabled:cursor-not-allowed disabled:opacity-50 dark:border-border-dark hover:dark:bg-bg-base-hover-dark',
+        props.className
+      )}
       style={{ width: props.width, ...props.style }}
     >
       {props.children}
@@ -27,7 +32,10 @@ export const Button: React.FC<ButtonProps> = (props) =>
       onClick={props.onClick}
       disabled={props.disabled}
       type={props.type}
-      className="flex cursor-pointer items-center justify-center rounded border border-border p-2 hover:bg-bg-base-hover disabled:cursor-not-allowed disabled:opacity-50 dark:border-border-dark hover:dark:bg-bg-base-hover-dark"
+      className={cn(
+        'flex cursor-pointer items-center justify-center rounded border border-border p-2 hover:bg-bg-base-hover disabled:cursor-not-allowed disabled:opacity-50 dark:border-border-dark hover:dark:bg-bg-base-hover-dark',
+        props.className
+      )}
       style={{ width: props.width, ...props.style }}
     >
       {props.children}

--- a/src/pages/todo/[id]/components/TaskDisplay.tsx
+++ b/src/pages/todo/[id]/components/TaskDisplay.tsx
@@ -14,7 +14,7 @@ type TaskDisplayProps = {
 export const TaskDisplay: React.FC<TaskDisplayProps> = ({ task, onEdit, isSubmitting = false }) => {
   return (
     <>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div className="flex items-center gap-2">
         <p>タイトル：{task.title}</p>
         <Button onClick={onEdit} disabled={isSubmitting}>
           編集

--- a/src/pages/todo/[id]/components/TaskDisplay.tsx
+++ b/src/pages/todo/[id]/components/TaskDisplay.tsx
@@ -13,17 +13,13 @@ type TaskDisplayProps = {
 
 export const TaskDisplay: React.FC<TaskDisplayProps> = ({ task, onEdit, isSubmitting = false }) => {
   return (
-    <>
-      <div className="flex items-center gap-2">
-        <p>タイトル：{task.title}</p>
-        <Button onClick={onEdit} disabled={isSubmitting}>
-          編集
-        </Button>
-      </div>
-      <p>
-        <small>説明：{task.description}</small>
-      </p>
+    <div className="relative border border-border p-2 dark:border-border-dark">
+      <p className="text-lg font-bold">{task.title}</p>
+      <Button onClick={onEdit} disabled={isSubmitting} className="absolute top-2 right-2">
+        編集
+      </Button>
+      <p>説明：{task.description}</p>
       <p>状態：{task.is_done ? '完了' : '未完了'}</p>
-    </>
+    </div>
   );
 };

--- a/src/pages/todo/[id]/components/TaskDisplay.tsx
+++ b/src/pages/todo/[id]/components/TaskDisplay.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/components/common/button/Button';
+import React from 'react';
+
+type TaskDisplayProps = {
+  task: {
+    title: string;
+    description: string | null;
+    is_done: boolean;
+  };
+  onEdit: () => void;
+  isSubmitting?: boolean;
+};
+
+export const TaskDisplay: React.FC<TaskDisplayProps> = ({ task, onEdit, isSubmitting = false }) => {
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <p>タイトル：{task.title}</p>
+        <Button onClick={onEdit} disabled={isSubmitting}>
+          編集
+        </Button>
+      </div>
+      <p>
+        <small>説明：{task.description}</small>
+      </p>
+      <p>状態：{task.is_done ? '完了' : '未完了'}</p>
+    </>
+  );
+};

--- a/src/pages/todo/[id]/components/TaskEditForm.tsx
+++ b/src/pages/todo/[id]/components/TaskEditForm.tsx
@@ -56,7 +56,7 @@ export const TaskEditForm: React.FC<TaskEditFormProps> = ({
   }, [task, reset, onCancel]);
 
   return (
-    <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-2">
+    <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col">
       <TextField control={control} name="title" label="タイトル" required disabled={isSubmitting} />
       <TextField control={control} name="description" label="説明" disabled={isSubmitting} />
       <div className="flex gap-2">

--- a/src/pages/todo/[id]/components/TaskEditForm.tsx
+++ b/src/pages/todo/[id]/components/TaskEditForm.tsx
@@ -56,13 +56,10 @@ export const TaskEditForm: React.FC<TaskEditFormProps> = ({
   }, [task, reset, onCancel]);
 
   return (
-    <form
-      onSubmit={handleSubmit(handleFormSubmit)}
-      style={{ display: 'flex', flexFlow: 'column', gap: 8 }}
-    >
+    <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col gap-2">
       <TextField control={control} name="title" label="タイトル" required disabled={isSubmitting} />
       <TextField control={control} name="description" label="説明" disabled={isSubmitting} />
-      <div style={{ display: 'flex', gap: 8 }}>
+      <div className="flex gap-2">
         <Button type="submit" disabled={isSubmitting}>
           保存
         </Button>

--- a/src/pages/todo/[id]/components/TaskEditForm.tsx
+++ b/src/pages/todo/[id]/components/TaskEditForm.tsx
@@ -1,0 +1,75 @@
+import { Button } from '@/components/common/button/Button';
+import { TextField } from '@/components/common/input/TextField';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
+type TaskEditFormProps = {
+  task: {
+    title: string;
+    description: string | null;
+  };
+  onSubmit: (data: { title: string; description: string }) => Promise<boolean>;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+};
+
+export const TaskEditForm: React.FC<TaskEditFormProps> = ({
+  task,
+  onSubmit,
+  onCancel,
+  isSubmitting = false,
+}) => {
+  const { control, handleSubmit, reset } = useForm<{
+    title: string;
+    description: string;
+  }>({
+    defaultValues: {
+      title: task.title || '',
+      description: task.description || '',
+    },
+  });
+
+  // タスクデータが変更されたらフォームの値を更新
+  React.useEffect(() => {
+    reset({
+      title: task.title || '',
+      description: task.description || '',
+    });
+  }, [task, reset]);
+
+  const handleFormSubmit = React.useCallback(
+    async (formData: { title: string; description: string }) => {
+      const success = await onSubmit(formData);
+      if (success) {
+        // 成功時は親コンポーネントで編集モードを終了するので、ここでは何もしない
+      }
+    },
+    [onSubmit]
+  );
+
+  const handleFormCancel = React.useCallback(() => {
+    reset({
+      title: task.title || '',
+      description: task.description || '',
+    });
+    onCancel();
+  }, [task, reset, onCancel]);
+
+  return (
+    <form
+      onSubmit={handleSubmit(handleFormSubmit)}
+      style={{ display: 'flex', flexFlow: 'column', gap: 8 }}
+    >
+      <TextField control={control} name="title" label="タイトル" required disabled={isSubmitting} />
+      <TextField control={control} name="description" label="説明" disabled={isSubmitting} />
+      <div style={{ display: 'flex', gap: 8 }}>
+        <Button type="submit" disabled={isSubmitting}>
+          保存
+        </Button>
+        <Button type="button" onClick={handleFormCancel} disabled={isSubmitting}>
+          キャンセル
+        </Button>
+      </div>
+    </form>
+  );
+};

--- a/src/pages/todo/[id]/index.tsx
+++ b/src/pages/todo/[id]/index.tsx
@@ -79,7 +79,7 @@ export const TodoDetailPage: React.FC = () => {
   return (
     <AppLayout>
       <h1>Todo Detail</h1>
-      <div style={{ display: 'flex', flexFlow: 'column', gap: 8, padding: 8 }}>
+      <div className="flex flex-col gap-2 p-2">
         {isLoading && (
           <>
             <Skeleton />
@@ -108,7 +108,7 @@ export const TodoDetailPage: React.FC = () => {
             アクション追加
           </Button>
         </div>
-        <div style={{ display: 'flex', flexFlow: 'column', gap: 8, padding: 8 }}>
+        <div className="flex flex-col gap-2 p-2">
           {isActionsLoading && (
             <>
               <Skeleton />
@@ -119,7 +119,7 @@ export const TodoDetailPage: React.FC = () => {
           <div>
             {actions?.map((action) => (
               <div key={action.id}>
-                <label style={{ display: 'flex', gap: 8 }}>
+                <label className="flex gap-2">
                   <input
                     type="checkbox"
                     checked={action.is_done}

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,11 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+/**
+ * クラス名を結合し、Tailwind CSSのクラス競合を解決するユーティリティ関数
+ * @param inputs - 結合するクラス名（文字列、配列、オブジェクトなど）
+ * @returns 結合されたクラス名の文字列
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { cn } from '@/utils/cn';


### PR DESCRIPTION
eslint の余計な記述もあったので削除

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add in-place edit for a task’s title/description on the todo detail page, introduce `cn` utility with `clsx`/`tailwind-merge`, update `Button` to accept `className`, and relax an ESLint rule.
> 
> - **Todo Detail**
>   - Add inline edit flow for task fields using `TaskDisplay` and `TaskEditForm` in `src/pages/todo/[id]/`.
>   - Integrate `useTodoUpdate` and `mutate` from SWR to persist and refresh task updates.
>   - Replace inline styles with Tailwind classes.
> - **UI Components**
>   - Update `Button` (`src/components/common/button/Button.tsx`): supports `className` and uses `cn` for class merging.
> - **Utilities**
>   - Add `cn` utility (`src/utils/cn.ts`) and re-export in `src/utils/index.ts` using `clsx` + `tailwind-merge`.
> - **Config/Deps**
>   - ESLint: turn off `arrow-body-style` rule.
>   - Add deps: `clsx`, `tailwind-merge`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e63a81c138fb22c6aa2221bfd243e30a5450f60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->