### PR TITLE
feat: タスク表示・編集で日付も表示・編集できるように

### DIFF
--- a/src/pages/todo/[id]/components/TaskDisplay.tsx
+++ b/src/pages/todo/[id]/components/TaskDisplay.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/common/button/Button';
+import dayjs from 'dayjs';
 import React from 'react';
 
 type TaskDisplayProps = {
@@ -6,6 +7,7 @@ type TaskDisplayProps = {
     title: string;
     description: string | null;
     is_done: boolean;
+    expired_at: string | null;
   };
   onEdit: () => void;
   isSubmitting?: boolean;
@@ -20,6 +22,9 @@ export const TaskDisplay: React.FC<TaskDisplayProps> = ({ task, onEdit, isSubmit
       </Button>
       <p>説明：{task.description}</p>
       <p>状態：{task.is_done ? '完了' : '未完了'}</p>
+      <p>
+        期限：{task.expired_at ? dayjs(task.expired_at).format('YYYY年MM月DD日 HH:mm') : 'なし'}
+      </p>
     </div>
   );
 };

--- a/src/pages/todo/[id]/components/TaskEditForm.tsx
+++ b/src/pages/todo/[id]/components/TaskEditForm.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/common/button/Button';
 import { TextField } from '@/components/common/input/TextField';
+import dayjs from 'dayjs';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -7,10 +8,18 @@ type TaskEditFormProps = {
   task: {
     title: string;
     description: string | null;
+    expired_at: string | null;
   };
-  onSubmit: (data: { title: string; description: string }) => Promise<boolean>;
+  onSubmit: (data: { title: string; description: string; expired_at: string }) => Promise<boolean>;
   onCancel: () => void;
   isSubmitting?: boolean;
+};
+
+// ISO形式の日時文字列をdatetime-local形式に変換
+const formatDateTimeLocal = (isoString: string | null): string => {
+  if (!isoString) return '';
+  // ISO形式（YYYY-MM-DDTHH:mm:ss.sssZ）をdatetime-local形式（YYYY-MM-DDTHH:mm）に変換
+  return dayjs(isoString).format('YYYY-MM-DDTHH:mm');
 };
 
 export const TaskEditForm: React.FC<TaskEditFormProps> = ({
@@ -22,10 +31,12 @@ export const TaskEditForm: React.FC<TaskEditFormProps> = ({
   const { control, handleSubmit, reset } = useForm<{
     title: string;
     description: string;
+    expired_at: string;
   }>({
     defaultValues: {
       title: task.title || '',
       description: task.description || '',
+      expired_at: formatDateTimeLocal(task.expired_at),
     },
   });
 
@@ -34,11 +45,12 @@ export const TaskEditForm: React.FC<TaskEditFormProps> = ({
     reset({
       title: task.title || '',
       description: task.description || '',
+      expired_at: formatDateTimeLocal(task.expired_at),
     });
   }, [task, reset]);
 
   const handleFormSubmit = React.useCallback(
-    async (formData: { title: string; description: string }) => {
+    async (formData: { title: string; description: string; expired_at: string }) => {
       const success = await onSubmit(formData);
       if (success) {
         // 成功時は親コンポーネントで編集モードを終了するので、ここでは何もしない
@@ -51,6 +63,7 @@ export const TaskEditForm: React.FC<TaskEditFormProps> = ({
     reset({
       title: task.title || '',
       description: task.description || '',
+      expired_at: formatDateTimeLocal(task.expired_at),
     });
     onCancel();
   }, [task, reset, onCancel]);
@@ -59,6 +72,13 @@ export const TaskEditForm: React.FC<TaskEditFormProps> = ({
     <form onSubmit={handleSubmit(handleFormSubmit)} className="flex flex-col">
       <TextField control={control} name="title" label="タイトル" required disabled={isSubmitting} />
       <TextField control={control} name="description" label="説明" disabled={isSubmitting} />
+      <TextField
+        control={control}
+        name="expired_at"
+        type="datetime-local"
+        label="期限"
+        disabled={isSubmitting}
+      />
       <div className="flex gap-2">
         <Button type="submit" disabled={isSubmitting}>
           保存

--- a/src/pages/todo/[id]/index.tsx
+++ b/src/pages/todo/[id]/index.tsx
@@ -57,11 +57,12 @@ export const TodoDetailPage: React.FC = () => {
   const { updateTodo, isSubmitting: isUpdateSubmitting } = useTodoUpdate({ mutate: mutateTask });
 
   const handleSubmit = React.useCallback(
-    async (formData: { title: string; description: string }) => {
+    async (formData: { title: string; description: string; expired_at: string }) => {
       if (!id || !task) return false;
       const success = await updateTodo(Number(id), {
         title: formData.title,
         description: formData.description,
+        expired_at: formData.expired_at || undefined,
       });
       if (success) {
         setIsEditing(false);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add due date support to task detail: show formatted deadline and edit via datetime-local, propagating to update API.
> 
> - **Frontend**
>   - **Task detail components**
>     - `TaskDisplay`: show `expired_at` formatted with `dayjs` (fallback to なし).
>     - `TaskEditForm`: add `expired_at` field (`datetime-local`), include format helper, update form types/defaults/reset, and submit `expired_at`.
>   - **Page logic**
>     - `src/pages/todo/[id]/index.tsx`: accept `expired_at` from form and pass to `updateTodo` (omit when empty).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24cff3343e998ca2df6ad5be599ba3d3260d8460. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->