### PR TITLE
ci: PR ワークフローに unit / Playwright テストを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,12 @@ jobs:
 
       - name: build
         run: npm run build
+
+      - name: unit test
+        run: npm run test
+
+      - name: install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright test
+        run: npm run test:e2e


### PR DESCRIPTION
## 概要
PR（opened / synchronize / reopened / ready_for_review）で、draft 以外のときに CI でビルドのあと Vitest と Playwright を実行するようにします。

## 変更
- `npm run build` の直後に `npm run test`（unit）
- Chromium の取得（`playwright install --with-deps chromium`）のあと `npm run test:e2e`

## 確認
- ローカルで `npm run test` / `npm run test:e2e` は通過済み

Made with [Cursor](https://cursor.com)